### PR TITLE
Bugfix: Correct filename in download URL for intel mac

### DIFF
--- a/Formula/cb.rb
+++ b/Formula/cb.rb
@@ -10,7 +10,7 @@ class Cb < Formula
   end
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://github.com/CrunchyData/bridge-cli/releases/download/v#{version}/cb-v#{version}_macos_arm64.zip"
+    url "https://github.com/CrunchyData/bridge-cli/releases/download/v#{version}/cb-v#{version}_macos_amd64.zip"
     sha256 "1e61508df88eb77a3ff4aac1f4303285ef0b5368273de3de3233b1b8c6aeca37"
   end
 


### PR DESCRIPTION
cb users on Intel Macs cannot upgrade to v3.5.1. `brew install cb` downloads the arm64.zip and the SHA comparison fails.

```sh
==> Fetching crunchydata/brew/cb
==> Downloading https://github.com/CrunchyData/bridge-cli/releases/download/v3.5.1/cb-v3.5.1_macos_arm64.zip
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/411434966/efe95e64-3637-4101-8365-5da540865db9?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetp
######################################################################################################################################################################################################### 100.0%
Error: SHA256 mismatch
Expected: 1e61508df88eb77a3ff4aac1f4303285ef0b5368273de3de3233b1b8c6aeca37
  Actual: fa27a40de8ca7c0b44ec287437f263f851aff06a8a7f0fd7a04b0d10c6a06ff6
    File: /Users/andy/Library/Caches/Homebrew/downloads/ff557562319491978fd355a4bc8d36af5734802c2eef0bad189d4f15ea149bab--cb-v3.5.1_macos_arm64.zip
To retry an incomplete download, remove the file above.
```